### PR TITLE
AltTab Fingertips - Allow prefix key in combination hotkeys to work

### DIFF
--- a/AltTab FingerTips/AltTab Fingertips.ahk
+++ b/AltTab FingerTips/AltTab Fingertips.ahk
@@ -85,7 +85,19 @@ return
 
 SetHotKeys:
 	if AltTabFingertipsHK
+	{
 		Hotkey,%AltTabFingertipsHK%,AltTabFingertips, ON
+		if InStr(AltTabFingertipsHK,"&")
+		{
+			prefix := StrSplit(AltTabFingertipsHK, A_Space)[1]
+			Hotkey,%prefix%,prefix_fix, ON
+		}
+	}
+return
+
+prefix_fix:
+    ; Allows retaining the prefix button functionality when pressed separately
+    Send {%prefix%}
 return
 
 CheckUpdate:


### PR DESCRIPTION
A workaround that will allow you to still be able to use the first key in a combination hotkey. 

Ex: a hotkey with `XButton1 & XButton2` will, [by default](https://www.autohotkey.com/docs/Hotkeys.htm#combo), prevent `Xbutton1` from working at all.

 This will fix that.